### PR TITLE
chore(levelup): add type to CrudRepository

### DIFF
--- a/src/main/java/com/greenfoxacademy/levelup/repository/IBadgeLevelRepository.java
+++ b/src/main/java/com/greenfoxacademy/levelup/repository/IBadgeLevelRepository.java
@@ -1,9 +1,10 @@
 package com.greenfoxacademy.levelup.repository;
 
+import com.greenfoxacademy.levelup.model.BadgeLevel;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface IBadgeLevelRepository extends CrudRepository {
+public interface IBadgeLevelRepository extends CrudRepository<BadgeLevel, Long> {
 
 }

--- a/src/main/java/com/greenfoxacademy/levelup/repository/IBadgeRepository.java
+++ b/src/main/java/com/greenfoxacademy/levelup/repository/IBadgeRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface IBadgeRepository extends CrudRepository<Badge, Level> {
+public interface IBadgeRepository extends CrudRepository<Badge, Long> {
 
 }

--- a/src/main/java/com/greenfoxacademy/levelup/repository/IBadgeRepository.java
+++ b/src/main/java/com/greenfoxacademy/levelup/repository/IBadgeRepository.java
@@ -1,9 +1,11 @@
 package com.greenfoxacademy.levelup.repository;
 
+import com.greenfoxacademy.levelup.model.Badge;
+import java.util.logging.Level;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface IBadgeRepository extends CrudRepository {
+public interface IBadgeRepository extends CrudRepository<Badge, Level> {
 
 }

--- a/src/main/java/com/greenfoxacademy/levelup/repository/IPersonRepository.java
+++ b/src/main/java/com/greenfoxacademy/levelup/repository/IPersonRepository.java
@@ -1,9 +1,10 @@
 package com.greenfoxacademy.levelup.repository;
 
+import com.greenfoxacademy.levelup.model.Person;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface IPersonRepository extends CrudRepository {
+public interface IPersonRepository extends CrudRepository<Person, Long> {
 
 }


### PR DESCRIPTION
set up the CrudRepository types in repository interfaces
(after it FTS-21 was pushed and merged, and there were models created)

<BadgleLevel, Long>
<Badge, Long>
<Person, Long>